### PR TITLE
Remove download=1 from direct play url

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -632,7 +632,7 @@ class Playable(object):
         if params.get('directPlay', False):
             locations = [i for i in self.iterParts() if i]
             for location in locations:
-                return self._server.url('%s?download=1' % location.key, includeToken=True)
+                return self._server.url(location.key, includeToken=True)
         mvb = params.get('maxVideoBitrate')
         vr = params.get('videoResolution', '')
         params = {


### PR DESCRIPTION
This fixes playback from a local server for me. If the `download=1` parameter is present my plex server gives me a 403